### PR TITLE
Restructure algorithm to minimize downtime of epic lists

### DIFF
--- a/trello
+++ b/trello
@@ -243,20 +243,16 @@ command :update do |c|
         tag_to_epic = {}
 
         epic_list.cards.each do |epic_card|
-          tags = []
           epic_card.name.scan(/\[[^\]]+\]/).each do |tag|
-            if tag != '[future]'
+            if tag != FUTURE_TAG
               tag_to_epic[tag] = epic_card
-              tags << tag
             end
           end
-
-          trello.clear_checklist_refs(epic_card, EPIC_REFERENCED_STORIES_NAME, tags)
-          trello.clear_checklist_refs(epic_card, FUTURE_EPIC_REFERENCED_STORIES_NAME, [FUTURE_TAG])
         end
         puts 'Tags:'
         puts tag_to_epic.keys.pretty_inspect
 
+        epic_stories_by_epic = {}
         (1..2).each do |accepted_pass|
           trello.boards.each do |board_id, board|
             if roadmap_board.prefs['permissionLevel'] == 'org' || roadmap_board.prefs['permissionLevel'] == board.prefs['permissionLevel']
@@ -313,27 +309,54 @@ command :update do |c|
                   puts "\n  List: #{list.name}  (#cards: #{cards.length})"
                   cards.each_with_index do |card, index|
                     card_tags = card.name.scan(/\[[^\]]+\]/)
+                    future = card_tags.include?(FUTURE_TAG) ? FUTURE_EPIC_REFERENCED_STORIES_NAME : EPIC_REFERENCED_STORIES_NAME
                     card_tags.each do |card_tag|
                       epic = tag_to_epic[card_tag]
                       if epic
                         if (roadmap_board.prefs['permissionLevel'] == 'org' && tag_to_epics[card_tag].length == 1) || (roadmap_board.prefs['permissionLevel'] == board.prefs['permissionLevel'])
-                          stories_checklist = trello.checklist(epic, card_tags.include?(FUTURE_TAG) ? FUTURE_EPIC_REFERENCED_STORIES_NAME : EPIC_REFERENCED_STORIES_NAME)
-                          if stories_checklist
-                            puts "Adding #{card.url} to #{epic.name}"
-                            (1..3).each do |i|
-                              begin
-                                stories_checklist.add_item("[#{card.name}](#{card.url}) (#{list.name}) (#{board.name})", accepted, 'bottom')
-                                break
-                              rescue => e
-                                puts "Error adding checklist: #{e.message}"
-                                raise if i == 3
-                              end
-                            end
-                          end
+                          epic_stories_by_epic[epic.id] = [] unless epic_stories_by_epic[epic.id]
+                          epic_stories_by_epic[epic.id] << [epic, card, list, board, future, accepted]
                         end
                       end
                     end
                   end
+                end
+              end
+            end
+          end
+        end
+        epic_stories_by_epic.each_value do |epic_stories|
+          first_epic_story = epic_stories.first
+          if first_epic_story
+            epic = first_epic_story[0]
+            tags = []
+            epic.name.scan(/\[[^\]]+\]/).each do |tag|
+              if tag != FUTURE_TAG
+                tags << tag
+              end
+            end
+            trello.clear_checklist_refs(epic, EPIC_REFERENCED_STORIES_NAME, tags)
+            trello.clear_checklist_refs(epic, FUTURE_EPIC_REFERENCED_STORIES_NAME, [FUTURE_TAG])
+          end
+
+          epic_stories.each do |epic_story|
+            epic = epic_story[0]
+            card = epic_story[1]
+            list = epic_story[2]
+            board = epic_story[3]
+            future = epic_story[4]
+            accepted = epic_story[5]
+
+            stories_checklist = trello.checklist(epic, future)
+            if stories_checklist
+              puts "Adding #{card.url} to #{epic.name}"
+              (1..3).each do |i|
+                begin
+                  stories_checklist.add_item("[#{card.name}](#{card.url}) (#{list.name}) (#{board.name})", accepted, 'bottom')
+                  break
+                rescue => e
+                  puts "Error adding checklist: #{e.message}"
+                  raise if i == 3
                 end
               end
             end


### PR DESCRIPTION
The old algorithm was:

- Remove all the cards links from the epics
- Go across all the boards and add each referencing card to it's corresponding epic as you find it

This had 2 problems:  

1) If we hit an error half way through the list it would leave a lot of epics without all their cards
2) There could be a long time period between when cards are removed from the epics and when they are readded

The new algorithm is:
- Find all the cards across all the boards that map to epics and remember them by epic
- For 1 epic at a time, remove the current card links and readd all the new links

So now the worst case for problem 1 is 1 epic might not have all its corresponding cards.  And the worst case for problem 2 is only a few seconds of the corresponding cards missing.
