### PR TITLE
Added support for additional epic backlog boards

### DIFF
--- a/config/trello.yml
+++ b/config/trello.yml
@@ -19,6 +19,7 @@
 :docs_new_list_name: New
 :organization_id: <organication short name>
 :organization_name: <organization display name>
+:roadmap_board_list: 'Epic Backlog, New'
 :sprint_length_in_weeks: 3
 :sprint_start_day: monday
 :sprint_end_day: friday

--- a/config/trello.yml
+++ b/config/trello.yml
@@ -19,7 +19,7 @@
 :docs_new_list_name: New
 :organization_id: <organication short name>
 :organization_name: <organization display name>
-:roadmap_board_list:
+:roadmap_board_lists:
  - 'New'
  - 'Epic Backlog'
 :sprint_length_in_weeks: 3

--- a/config/trello.yml
+++ b/config/trello.yml
@@ -19,7 +19,9 @@
 :docs_new_list_name: New
 :organization_id: <organication short name>
 :organization_name: <organization display name>
-:roadmap_board_list: 'Epic Backlog, New'
+:roadmap_board_list:
+ - 'New'
+ - 'Epic Backlog'
 :sprint_length_in_weeks: 3
 :sprint_start_day: monday
 :sprint_end_day: friday

--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -122,15 +122,15 @@ class TrelloHelper
   end
 
   def epic_lists(board)
-    list = []
-    target_boards = roadmap_board_list.split(',').map(&:strip) || 'Epic Backlog'
-    p target_boards
+    lists = []
+    #target_boards = roadmap_board_list.split(',').map(&:strip) || 'Epic Backlog'
+    target_boards = roadmap_board_list || ['Epic Backlog']
     board.lists.each do |l|
       if target_boards.include?(l.name)
-        list.push(l)
+        lists.push(l)
       end
     end
-    list
+    lists
   end
 
   def documentation_next_list

--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -106,12 +106,14 @@ class TrelloHelper
   def tag_to_epics
     tag_to_epics = {}
     roadmap_boards.each do |roadmap_board|
-      epic_list = epic_list(roadmap_board)
-      epic_list.cards.each do |epic_card|
-        epic_card.name.scan(/\[[^\]]+\]/).each do |tag|
-          if tag != '[future]'
-            tag_to_epics[tag] = [] unless tag_to_epics[tag]
-            tag_to_epics[tag] << epic_card
+      epic_lists = epic_lists(roadmap_board)
+      epic_lists.each do |epic_list|
+        epic_list.cards.each do |epic_card|
+          epic_card.name.scan(/\[[^\]]+\]/).each do |tag|
+            if tag != '[future]'
+              tag_to_epics[tag] = [] unless tag_to_epics[tag]
+              tag_to_epics[tag] << epic_card
+            end
           end
         end
       end
@@ -119,12 +121,11 @@ class TrelloHelper
     tag_to_epics
   end
 
-  def epic_list(board)
-    list = nil
+  def epic_lists(board)
+    list = []
     board.lists.each do |l|
-      if l.name == 'Epic Backlog'
-        list = l
-        break
+      if l.name == 'Epic Backlog' or l.name == 'Top 5 Priorities' or l.name == 'New'
+        list.push(l)
       end
     end
     list

--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -7,7 +7,7 @@ class TrelloHelper
                 :public_roadmap_id, :public_roadmap_board, :documentation_board,
                 :documentation_next_list, :docs_planning_id, :organization_name,
                 :sprint_length_in_weeks, :sprint_start_day, :sprint_end_day, :logo,
-                :docs_new_list_name
+                :docs_new_list_name, :roadmap_board_list
 
   attr_accessor :boards
 
@@ -123,8 +123,10 @@ class TrelloHelper
 
   def epic_lists(board)
     list = []
+    target_boards = roadmap_board_list.split(',').map(&:strip) || 'Epic Backlog'
+    p target_boards
     board.lists.each do |l|
-      if l.name == 'Epic Backlog' or l.name == 'Top 5 Priorities' or l.name == 'New'
+      if target_boards.include?(l.name)
         list.push(l)
       end
     end

--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -7,7 +7,7 @@ class TrelloHelper
                 :public_roadmap_id, :public_roadmap_board, :documentation_board,
                 :documentation_next_list, :docs_planning_id, :organization_name,
                 :sprint_length_in_weeks, :sprint_start_day, :sprint_end_day, :logo,
-                :docs_new_list_name, :roadmap_board_list
+                :docs_new_list_name, :roadmap_board_lists
 
   attr_accessor :boards
 
@@ -123,8 +123,7 @@ class TrelloHelper
 
   def epic_lists(board)
     lists = []
-    #target_boards = roadmap_board_list.split(',').map(&:strip) || 'Epic Backlog'
-    target_boards = roadmap_board_list || ['Epic Backlog']
+    target_boards = roadmap_board_lists || ['Epic Backlog']
     board.lists.each do |l|
       if target_boards.include?(l.name)
         lists.push(l)

--- a/trello
+++ b/trello
@@ -273,19 +273,19 @@ command :update do |c|
     if options.update_roadmap
       tag_to_epics = trello.tag_to_epics
       trello.roadmap_boards.each do |roadmap_board|
-        epic_list = trello.epic_list(roadmap_board)
+        epic_lists = trello.epic_lists(roadmap_board)
         tag_to_epic = {}
-
-        epic_list.cards.each do |epic_card|
-          epic_card.name.scan(/\[[^\]]+\]/).each do |tag|
-            if tag != FUTURE_TAG
-              tag_to_epic[tag] = epic_card
+        epic_lists.each do |epic_list|
+          epic_list.cards.each do |epic_card|
+            epic_card.name.scan(/\[[^\]]+\]/).each do |tag|
+              if tag != FUTURE_TAG
+                tag_to_epic[tag] = epic_card
+              end
             end
           end
         end
         puts 'Tags:'
         puts tag_to_epic.keys.pretty_inspect
-
         epic_stories_by_epic = {}
         (1..2).each do |accepted_pass|
           trello.boards.each do |board_id, board|
@@ -359,9 +359,11 @@ command :update do |c|
             end
           end
         end
-        epic_list.cards.each do |epic_card|
-          unless epic_stories_by_epic[epic_card.id]
-            clear_epic_refs(epic_card, trello)
+        epic_lists.each do |epic_list|
+          epic_list.cards.each do |epic_card|
+            unless epic_stories_by_epic[epic_card.id]
+              clear_epic_refs(epic_card, trello)
+            end
           end
         end
         epic_stories_by_epic.each_value do |epic_stories|


### PR DESCRIPTION
I've tested this for cases where the board doesn't exist.  For example the OpenShift board doesn't have a "top 5 priorities" board.  The script behaves as you would expect it to.