### PR TITLE
Adding a new perf label to this report

### DIFF
--- a/templates/labels_overview.erb
+++ b/templates/labels_overview.erb
@@ -76,7 +76,7 @@
                 labels = trello.card_labels(card)
                 label_names = labels.map{ |label| label.name }
                 label_names.each do |label_name|
-                  if ['blocked', 'documentation', 'security'].include?(label_name)
+                  if ['blocked', 'documentation', 'perf', 'security'].include?(label_name)
                     break if label_name == 'documentation' && label_names.include?('docs-ack')
                     label_data[label_name] = [] unless label_data[label_name]
                     label_data[label_name] << [card, board]


### PR DESCRIPTION
@danmcp - tell me if I followed the logic of your changes and made the change I needed to. My intent is to give the performance team the ability to label cards they are working on (on the many boards they work across) and have a list generated. I will also add a "perf" label to the appropriate place in trello.