### PR TITLE
Iterate over all boards and back them up

### DIFF
--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -655,6 +655,27 @@ class TrelloHelper
     boards[board_id]
   end
 
+  def dump_board_json(board)
+    board = board(board) unless board.respond_to? :id
+    board_json_url = "#{board.url}.json"
+    request = Trello::Request.new :get, board_json_url, {}, nil
+    response = nil
+    i = 0
+    while true
+      trello_do('dump_board_json') do
+        response = Trello::TInternet.execute Trello.auth_policy.authorize(request)
+        return response.body if response.code == 200
+      end
+      err_msg = "Error with dump_board_json backing up board '#{board.name}': " + (response.code.nil? ? "HTTP Timeout?" : "HTTP response code: #{response.code}, response body: #{response.body}")
+      if i >= DEFAULT_RETRIES
+        raise err_msg
+      end
+      $stderr.puts err_msg
+      sleep DEFAULT_RETRY_SLEEP
+      i += 1
+    end
+  end
+
   def member(member_name)
     Trello::Member.find(member_name)
   end

--- a/trello
+++ b/trello
@@ -97,6 +97,35 @@ end
 
 trello = load_conf(TrelloHelper, CONFIG.trello, true)
 
+command :backup_org_boards do |c|
+
+  c.option "--output-dir DIRECTORY", "Directory to dump backup json to"
+
+  c.syntax = "#{name}"
+  c.description = "dump all organization boards"
+  c.action do |args, options|
+    output_dir = (options.output_dir.nil? || options.output_dir.empty?) ? Pathname.pwd : Pathname.new(options.output_dir)
+    if !output_dir.writable?
+      $stderr.puts "Directory #{output_dir} doesn't specify a writable directory."
+      exit 1
+    end
+    trello.boards.each do |board_id, board|
+      unless board.nil?
+        out_filename = "#{board.url.split('/').last}.json"
+        out_path = File.join(output_dir, out_filename)
+        puts "Backing up #{board.name} to #{out_path}"
+        begin
+          # cache the response so we don't create a 0-byte file if the request times out
+          output = trello.dump_board_json(board)
+          File.open(out_path, 'w') { |f| f.write(output)}
+        rescue Exception => e
+          $stderr.puts "Error while writing to #{out_path}: #{e.message}"
+        end
+      end
+    end
+  end
+end
+
 command :list do |c|
   c.syntax = "#{name} list"
 


### PR DESCRIPTION
Adds `backup_org_boards` which takes `--output-dir` argument. Iterates over all boards in the organization and dumps the JSON export to `<output-dir>/<board-name>.json`, or `$PWD/<board-name.json>` if no `--output-dir` is specified.
