### PR TITLE
Get card labels from card object, not API

### DIFF
--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -472,8 +472,8 @@ class TrelloHelper
   def card_labels(card)
     labels = @labels_by_card[card.id]
     return labels if labels
-    trello_do('card_labels') do
-      labels = card.labels
+    labels = card.card_labels.map do |label|
+      Trello::Label.new(label)
     end
     @labels_by_card[card.id] = labels if labels
     labels


### PR DESCRIPTION
The `Trello::Card` object stores the card label data in a hash, which is
now being used to instantiate the `Trello::Label` objects instead of
`card.labels`, which triggers an extra API call.