### PR TITLE
trello_helper.rb: update card_labels for new gem

### DIFF
--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -472,9 +472,7 @@ class TrelloHelper
   def card_labels(card)
     labels = @labels_by_card[card.id]
     return labels if labels
-    labels = card.card_labels.map do |label|
-      Trello::Label.new(label)
-    end
+    labels = card.labels
     @labels_by_card[card.id] = labels if labels
     labels
   end


### PR DESCRIPTION
`ruby-trello` gem version 1.5.1 includes a change to the data structure
returned by `card.labels`. This change accounts for that and fixes https://github.com/openshift/sprint_tools/issues/48