### PR TITLE
Tweaks to handle new labels, convenience functions for adding/listing roadmap labels

### DIFF
--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -28,7 +28,7 @@ class TrelloHelper
   RELEASE_COMPLETE_REGEX = /^Complete ((\d+)\.(\d+)(.(\d+))?(.(\d+))?)/
   SPRINT_REGEXES = Regexp.union([SPRINT_REGEX, DONE_REGEX, RELEASE_COMPLETE_REGEX])
 
-  RELEASE_LABEL_REGEX = /^(proposed|targeted|committed)-((\w*)-)*((\d+)(.(\d+))?(.(\d+))?(.(\d+))*)/
+  RELEASE_LABEL_REGEX = /^(proposed|targeted|committed)-((\w*)-)*((?:fy)?(\d+)(.((?:q)?\d+))?(.(\d+))?(.(\d+))*)/
 
   STAR_LABEL_REGEX = /^([1-5])star$/
 
@@ -1545,8 +1545,12 @@ class TrelloHelper
       label_data = SortableCard.new()
       label_data.state = $1 if $1
       label_data.product = $3 ? $3 : 'ocp'
-      label_data.release = Gem::Version.new($4) if $4
-      @sortable_card_labels[label.name] = label_data
+      if $4
+        version = $4
+        version.gsub!(/^fy/, "0.")
+        label_data.release = Gem::Version.new(version)
+      end
+    @sortable_card_labels[label.name] = label_data
     end
     label_data
   end

--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -1157,6 +1157,13 @@ class TrelloHelper
     end
   end
 
+  def print_labels(board=roadmap_board)
+    label_names = board_labels(board).map{ |l| l.name }
+    puts "\n  Board: #{board.name}  (#labels #{label_names.length})"
+    puts "    Labels:"
+    label_names.sort.each { |n| puts "      #{n}" }
+  end
+
   def card_by_ref(card_ref)
     card = nil
     if card_ref =~ /^(\w+)_(\d+)/i

--- a/trello
+++ b/trello
@@ -361,6 +361,24 @@ command :list do |c|
   end
 end
 
+command :list_roadmap_labels do |c|
+  c.syntax = "#{name} list"
+
+  c.option "--board board_name", "List labels on a particular board (defaults to Private AtomicOpenShift Roadmap)"
+  c.action do |args, options|
+    if options.board_name
+      board = trello.boards.find { |b| b.name == options.board_name }
+      if board
+        trello.print_labels(board)
+      else
+        puts "Couldn't find board named \"#{options.board_name}\""
+      end
+    else
+      trello.print_labels
+    end
+  end
+end
+
 command :sprint_identifier do |c|
   c.syntax = "#{name} sprint_identifier"
 
@@ -788,6 +806,27 @@ command :rename_label do |c|
         puts "  Updating label #{from} to #{to}"
         board_label.name = options.to
         trello.update_label(board_label)
+      end
+    end
+  end
+end
+
+command :create_roadmap_labels do |c|
+  c.syntax = "#{name} create_roadmap_labels LABEL1 LABEL2 ..."
+  c.description = "creates each of LABEL1 LABEL2 ... as labels on the roadmap board"
+  c.action do |args, options|
+    puts "args: #{args} options: #{options}"
+    roadmap_label_names = trello.board_labels(trello.roadmap_board).map{|l| l.name}
+    args.each do |new_label_name|
+      if roadmap_label_names.include? new_label_name
+        puts "Not creating duplicate label: #{new_label_name}"
+      else
+        puts "Creating label: #{new_label_name}"
+        begin
+          trello.create_label(new_label_name, nil, trello.roadmap_id)
+        rescue Exception => e
+          $stderr.puts "Error while creating label named #{new_label_name} on board #{trello.roadmap_board.name}: #{e.message}"
+        end
       end
     end
   end


### PR DESCRIPTION
We're adding labels that look like "`committed-online-fy18.q2`", so `TrelloHelper::RELEASE_LABEL_REGEX` and `TrelloHelper#sortable_card_label` need to be updated to parse and sort cards with these new style labels.

Also adds convenience functions for messing around with roadmap labels.