### PR TITLE
Rewrite RELEASE_LABEL_REGEX code to use .match, tweak regex

### DIFF
--- a/templates/developers_overview.erb
+++ b/templates/developers_overview.erb
@@ -172,15 +172,15 @@
             label_names = labels.map{ |label| label.name }
             releases = []
             label_names.each do |label_name|
-              if label_name =~ TrelloHelper::RELEASE_LABEL_REGEX
-                product = $3
-                release = $4
+              TrelloHelper::RELEASE_LABEL_REGEX.match(label_name) do |fields| 
+                product = fields[2]
+                release = fields[3]
                 if sizing
                   release_key = product ? "#{product}-#{release}" : release
                   sizings_by_release[release_key] = 0 unless sizings_by_release[release_key]
                   sizings_by_release[release_key] += sizing
                 end
-                releases << [product, label_name, $1, release]
+                releases << [product, label_name, fields[1], release]
               end
             end
 %>

--- a/templates/releases_overview.erb
+++ b/templates/releases_overview.erb
@@ -108,14 +108,14 @@
           labels = trello.card_labels(card)
           label_names = labels.map{ |label| label.name }
           label_names.each do |label_name|
-            if label_name =~ TrelloHelper::RELEASE_LABEL_REGEX
-              if product == $3
-                state = $1
-                release = $4
-                major = $5.to_i
-                minor = $7.to_i
-                patch = $9.to_i
-                hotfix = $11.to_i
+            TrelloHelper::RELEASE_LABEL_REGEX.match(label_name) do |fields|
+              if product == fields[2]
+                state = fields[1]
+                release = fields[3]
+                major = fields[4].to_i
+                minor = fields[5].to_i
+                patch = fields[6].to_i
+                hotfix = fields[7].to_i
                 orig_state = state
                 if complete
                   state = 'committed'
@@ -303,12 +303,14 @@
                   epic_card = tag_to_epics[label_name].first
                 end
                 epics << [label_name[5..-1], epic_card ? epic_card.url : nil]
-              elsif label_name =~ TrelloHelper::RELEASE_LABEL_REGEX
-                if product != $3
-                  addtl_releases << [$3, label_name, $1, $4]
-                end
               elsif label_name == TrelloHelper::STAGE1_DEP_LABEL
                 stage1_dep_indicator = '*'
+              else
+                TrelloHelper::RELEASE_LABEL_REGEX.match(label_name) do |fields|
+                  if product != fields[2]
+                    addtl_releases << [fields[2], label_name, fields[1], fields[3]]
+                  end
+                end
               end
             end
 
@@ -427,8 +429,8 @@
               labels = trello.card_labels(card)
               label_names = labels.map{ |label| label.name }
               label_names.each do |label_name|
-                if label_name =~ TrelloHelper::RELEASE_LABEL_REGEX
-                  other_releases << [$3, label_name, $1, $4]
+                TrelloHelper::RELEASE_LABEL_REGEX.match(label_name) do |fields|
+                  other_releases << [fields[2], label_name, fields[1], fields[3]]
                 end
               end
             end

--- a/templates/sprint_schedule.erb
+++ b/templates/sprint_schedule.erb
@@ -47,14 +47,14 @@
       if trello.sprint_card
         current_release = ''
         if trello.current_release_labels && !trello.current_release_labels.empty?
-          if trello.current_release_labels.first =~ TrelloHelper::RELEASE_LABEL_REGEX
-            current_release = "#{$4} "
+          TrelloHelper::RELEASE_LABEL_REGEX.match(trello.current_release_labels.first) do |fields|
+            current_release = "#{fields[3]} "
           end
         end
         next_release = 'Next '
         if trello.next_release_labels && !trello.next_release_labels.empty?
-          if trello.next_release_labels.first =~ TrelloHelper::RELEASE_LABEL_REGEX
-            next_release = "#{$4} "
+          TrelloHelper::RELEASE_LABEL_REGEX.match(trello.current_release_labels.first) do |fields|
+            next_release = "#{fields[3]} "
           end
         end
         if trello.sprint_card.name =~ TrelloHelper::SPRINT_REGEX

--- a/templates/teams_overview.erb
+++ b/templates/teams_overview.erb
@@ -93,14 +93,14 @@
           labels = trello.card_labels(card)
           label_names = labels.map{ |label| label.name }
           label_names.each do |label_name|
-            if label_name =~ TrelloHelper::RELEASE_LABEL_REGEX
-              state = $1
-              product = $3
-              release = $4
-              major = $5.to_i
-              minor = $7.to_i
-              patch = $9.to_i
-              hotfix = $11.to_i
+          TrelloHelper::RELEASE_LABEL_REGEX.match(label_name) do |fields|
+              state = fields[1]
+              product = fields[2]
+              release = fields[3]
+              major = fields[4].to_i
+              minor = fields[5].to_i
+              patch = fields[6].to_i
+              hotfix = fields[7].to_i
               orig_state = state
               if complete
                 state = 'committed'
@@ -262,12 +262,14 @@
                   epic_card = tag_to_epics[label_name].first
                 end
                 epics << [label_name[5..-1], epic_card ? epic_card.url : nil]
-              elsif label_name =~ TrelloHelper::RELEASE_LABEL_REGEX
-                if product != $3
-                  addtl_releases << [$3, label_name, $1, $4]
-                end
               elsif label_name == TrelloHelper::STAGE1_DEP_LABEL
                 stage1_dep_indicator = '*'
+              else
+                TrelloHelper::RELEASE_LABEL_REGEX.match(label_name) do |fields|
+                  if product != fields[2]
+                    addtl_releases << [fields[2], label_name, fields[1], fields[3]]
+                  end
+                end
               end
             end
 
@@ -377,8 +379,8 @@
               labels = trello.card_labels(card)
               label_names = labels.map{ |label| label.name }
               label_names.each do |label_name|
-                if label_name =~ TrelloHelper::RELEASE_LABEL_REGEX
-                  other_releases << [$3, label_name, $1, $4]
+                TrelloHelper::RELEASE_LABEL_REGEX.match(label_name) do |fields|
+                  other_releases << [fields[2], label_name, fields[1], fields[3]]
                 end
               end
             end

--- a/trello
+++ b/trello
@@ -398,8 +398,8 @@ command :release_identifier do |c|
   c.description = "Print the release identifier"
   c.action do |args, options|
     if trello.current_release_labels && !trello.current_release_labels.empty?
-      if trello.current_release_labels.first =~ TrelloHelper::RELEASE_LABEL_REGEX
-        print "#{$4}"
+      TrelloHelper::RELEASE_LABEL_REGEX.match(trello.current_release_labels.first) do |fields|
+        print "#{fields[3]}"
       end
     end
   end


### PR DESCRIPTION
These changes:

* fix a regex to extract version numbers from our `-fy18.q3` style
  labels for sorting
  * also support any non-digit prefix for the version/release number
    parts, e.g. `-fy18.q3.r2.4`
* drop some of the captured groups so that we only pull out the parts
  of the label that we're using
* update dependent code to use `.match` and to reference the capture
  groups in the result according to the changes mentioned above

Sometimes you need an ASCII diagram to understand a regex :/