### PR TITLE
Fixup trello days_left_in_sprint

### DIFF
--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -376,6 +376,10 @@ class TrelloHelper
     end
   end
 
+  def sprint_length_in_days
+    @sprint_length_in_days ||= (@sprint_length_in_weeks * 7)
+  end
+
   def boards
     return @boards if @boards
     @boards = {}

--- a/trello
+++ b/trello
@@ -410,7 +410,12 @@ command :days_left_in_sprint do |c|
 
   c.description = "Print the number of days left in the sprint"
   c.action do |args, options|
-    print ((trello.sprint_card.due.to_time - Time.new) / (60*60*24)).ceil
+    # Take the modulo by trello.sprint_length_in_days (21), since the
+    # last Wednesday of each sprint is when the sprint card usually is
+    # updated. From that point until Saturday, the formula below would
+    # otherwise give an answer that doesn't make sense (e.g. 23 days
+    # left on Wednesday afternoon)
+    print (((trello.sprint_card.due.to_time - Time.new) / (60*60*24)).ceil % trello.sprint_length_in_days)
   end
 end
 


### PR DESCRIPTION
Takes the modulus of the days left in sprint against 21 (3 weeks) so
the output is correct even if the sprint card has been updated prior
to end of sprint.