### PR TITLE
Implement CSV export and initial unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ rvm:
 gemfile: Gemfile
 
 sudo: false
+
+language: ruby
+
+script: "bundle exec rake check_syntax test"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ Commands
             Card url Ex: https://trello.com/c/6EhPEbM4
 
 
+**create_roadmap_labels**
+
+    DESCRIPTION:
+        creates each of LABEL1 LABEL2 ... as labels on the configured roadmap board
+
+    OPTIONS:
+        LABEL1 [LABEL2 ...]
+            Labels names to be created
+
+
+**backup_org_boards**
+
+    DESCRIPTION:
+        dump a JSON backup of all organization boards to the specified directory
+
+    OPTIONS:
+        --out-dir DIRECTORY
+            Directory to dump backup json to
+
+
 **generate_roadmap_overview**
 
     DESCRIPTION:
@@ -115,6 +135,50 @@ Commands
             The dir to output to Ex: /tmp
 
 
+**generate_developers_overview**
+
+    DESCRIPTION:
+        Generate the developers overview
+
+    OPTIONS:
+        --out OUT_FILE 
+            The file to output Ex: /tmp/developers_overview.html
+
+
+**generate_raw_overview**
+
+    DESCRIPTION:
+        Generate a CSV-formatted file containing the card data used in the overview pages, suitable to importing into a spreadsheet.
+
+    OPTIONS:
+        --out OUT_FILE
+            The file to output Ex: /tmp/raw_overview.csv
+
+
+**generate_release_json**
+
+    DESCRIPTION:
+        Generate json for the cards in a release
+
+    OPTIONS:
+        --out-dir DIRECTORY 
+            The dir to output to Ex: /tmp
+        --release RELEASE 
+            Release to build json for Ex: 3.3
+        --product PRODUCT 
+            Product to build json for Ex: myproduct
+
+
+**generate_trello_login_to_email_json**
+
+    DESCRIPTION:
+        Generate a json file with trello login -> email
+
+    OPTIONS:
+        --out OUT_FILE 
+            File to output the resulting json to Ex: /tmp/trello_login_to_email.json
+
+
 **list**
 
     DESCRIPTION:
@@ -133,6 +197,16 @@ Commands
 
     DESCRIPTION:
         List the potentially invalid users
+
+
+**list_roadmap_labels**
+
+    DESCRIPTION:
+        List the labels belonging to a board, defaulting to the Roadmap board designated in the configuration.
+
+    OPTIONS:
+        --board BOARD_NAME
+            List labels on a particular board
 
 
 **organize_release_cards**
@@ -157,6 +231,12 @@ Commands
             Send email?
 
 
+**release_identifier**
+
+    DESCRIPTION:
+        Print the release identifier
+
+
 **sprint_identifier**
 
     DESCRIPTION:
@@ -167,6 +247,24 @@ Commands
 
     DESCRIPTION:
         Print the number of days left in the sprint
+
+
+**days_until_code_freeze**
+
+    DESCRIPTION:
+        Print the number of days left until the next code freeze
+
+
+**days_until_feature_complete**
+
+    DESCRIPTION:
+        Print the number of days left until feature_complete
+
+
+**days_until_stage_one_dep_complete**
+
+    DESCRIPTION:
+        Print the number of days left until stage one dependencies are feature complete
 
 
 **update**
@@ -199,6 +297,18 @@ Commands
 
     DESCRIPTION:
         Convert [] markers on cards to epic- and future labels that exist
+
+
+**rename_label**
+
+    DESCRIPTION:
+        Renames a label on all configured boards
+
+    OPTIONS:
+        --from FROM
+            The label to rename
+        --to TO
+            What to rename it to
 
 
 Detailed Run Example

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,23 @@
 require 'rubygems'
+require 'rake/testtask'
 
 $stdout.sync = true
 $stderr.sync = true
 
-namespace :sprint_tools do
+task :default => "check_syntax"
 
-  desc "Check syntax"
+Rake::TestTask.new(:test) do |t|
+  t.libs.unshift("test")
+  t.verbose = true
+  t.test_files = FileList["test/**/test_*.rb"]
+end
+
+desc "Check syntax"
   task :check_syntax do
 
     syntax_check_cmd = %{
 set -e
-for f in `find lib -name *.rb`
+for f in `find ./ -name *.rb`
 do
   ruby -c $f >/dev/null;
 done
@@ -21,6 +28,3 @@ ruby -c trello >/dev/null;
       exit 1
     end
   end
-end
-
-task :default => "sprint_tools:check_syntax"

--- a/lib/overviews_helper.rb
+++ b/lib/overviews_helper.rb
@@ -1,0 +1,189 @@
+require 'csv'
+require 'trello_helper'
+
+class OverviewsHelper
+
+  attr_accessor :trello, :bugzilla
+
+  CSV_HEADER = [ "Product(s)",
+               "Product:Release",
+               "Product:State",
+               "Card Title",
+               "URL",
+               "Team",
+               "Board",
+               "Board URL",
+               "List",
+               "Status",
+               "Epics",
+               "Sizing",
+               "Members",
+               "Card ID" ]
+
+  def initialize(opts = nil)
+    if opts
+      opts.each do |k,v|
+        send("#{k}=",v)
+      end
+    end
+  end
+
+  def card_data_to_csv_row_array(card_data)
+    products = card_data[:products].keys.join("|")
+    prod_rel = card_data[:products].map { |product, data| "#{product}:#{data[0]}" }.join("|")
+    prod_state = card_data[:products].map { |product, data| "#{product}:#{data[1]}" }.join("|")
+    card_epics = card_data[:epics].join("|")
+    card_members = card_data[:members].join("|")
+    return [ products,
+             prod_rel,
+             prod_state,
+             card_data[:title],
+             card_data[:card_url],
+             card_data[:team_name],
+             card_data[:board_name],
+             card_data[:board_url],
+             card_data[:list],
+             card_data[:status],
+             card_epics,
+             card_data[:card_size],
+             card_members,
+             card_data[:id] ]
+  end
+
+  def card_data_from_card(card, team_name, board, list, status)
+    card_name = card.name
+    card_size = 0
+    TrelloHelper::CARD_NAME_REGEX.match(card.name) do |card_fields|
+      card_name = card_fields[3].strip
+      card_size = (card_fields[2] || "").strip
+    end
+    card_members = trello.card_members(card).map { |m| "#{m.full_name} (#{m.username})" }
+    card_data = { id: card.id,
+                  title: card_name,
+                  card_size: card_size,
+                  card_url: card.short_url,
+                  team_name: team_name,
+                  board_name: board.name,
+                  board_url: board.url,
+                  list: list.name,
+                  status: status,
+                  members: card_members }
+    card_data[:products] = {}
+    card_data[:epics] = []
+    labels = trello.card_labels(card)
+    label_names = labels.map{ |label| label.name }
+    label_names.each do |label_name|
+      if label_name.start_with?('epic-')
+        card_data[:epics] << label_name
+      else
+        TrelloHelper::RELEASE_LABEL_REGEX.match(label_name) do |fields|
+          if trello.valid_products.include?(fields[2])
+            product = fields[2]
+            state = fields[1]
+            release = fields[3]
+            if status == 'Complete'
+              state = 'committed'
+            end
+            card_data[:products][product] = [release, state]
+          end
+        end
+      end
+    end
+    card_data
+  end
+
+  def create_raw_overview_data(out)
+    cards_data = []
+    lists_for_team_boards  = []
+    # Leave this for ease of testing
+    # ["clusterlifecycle","continuousinfra","customersuccess"].each do |team|
+    trello.teams.each do |team_name, team|
+      if !team[:exclude_from_releases_overview]
+        trello.team_boards(team_name).each do |board|
+          trello.board_lists(board).each do |list|
+            lists_for_team_boards << [team_name.to_s, board, list]
+          end
+        end
+      end
+    end
+    lists_for_team_boards.each do |team_name, board, list|
+      if trello.list_for_completed_work?(list.name)
+        status = 'Complete'
+      elsif trello.list_for_in_progress_work?(list.name)
+        status = 'In Progress'
+      end
+      trello.list_cards(list).each do |card|
+        cards_data << card_data_from_card(card, team_name, board, list, status)
+      end
+    end
+    CSV.open(out, "wb") do |csv|
+      csv << CSV_HEADER
+      cards_data.each do |card_data|
+        csv << card_data_to_csv_row_array(card_data)
+      end
+    end
+  end
+
+  def create_releases_overview(out)
+    extname = File.extname out
+    filename = File.basename out, extname
+    dirname = File.dirname out
+
+    ((trello.other_products ? trello.other_products : []) + [nil]).each do |product|
+      erb = ERB.new(File.open('templates/releases_overview.erb', "rb").read)
+      file = nil
+      if product
+        file = File.join(dirname, "#{filename}_#{product}#{extname}")
+      else
+        file = out
+      end
+      File.open(file, 'w') {|f| f.write(erb.result(binding)) }
+    end
+  end
+
+  def create_teams_overview(out)
+    extname = File.extname out
+    filename = File.basename out, extname
+    dirname = File.dirname out
+
+    (trello.teams.keys + [nil]).each do |team|
+      erb = ERB.new(File.open('templates/teams_overview.erb', "rb").read)
+      file = nil
+      if team
+        file = File.join(dirname, "#{filename}_#{team}#{extname}")
+      else
+        file = out
+      end
+      File.open(file, 'w') {|f| f.write(erb.result(binding)) }
+    end
+  end
+
+  def create_developers_overview(out)
+    extname = File.extname out
+    filename = File.basename out, extname
+    dirname = File.dirname out
+
+    (trello.teams.keys + [nil]).each do |team|
+      erb = ERB.new(File.open('templates/developers_overview.erb', "rb").read)
+      file = nil
+      if team
+        file = File.join(dirname, "#{filename}_#{team}#{extname}")
+      else
+        file = out
+      end
+      File.open(file, 'w') {|f| f.write(erb.result(binding)) }
+    end
+  end
+
+  def create_labels_overview(out)
+    erb = ERB.new(File.open('templates/labels_overview.erb', "rb").read)
+    File.open(out, 'w') {|f| f.write(erb.result(binding)) }
+  end
+
+  def create_roadmap_overview(out)
+    erb = ERB.new(File.open('templates/roadmap_overview.erb', "rb").read)
+    File.open(out, 'w') {|f| f.write(erb.result(binding)) }
+  end
+
+
+end

--- a/templates/developers_overview.erb
+++ b/templates/developers_overview.erb
@@ -74,7 +74,7 @@
               list_name = list.name
               if list_name !~ TrelloHelper::SPRINT_REGEXES && !TrelloHelper::CURRENT_SPRINT_NOT_IN_PROGRESS_STATES.include?(list_name) && !TrelloHelper::NEW_STATES.include?(list_name) && !TrelloHelper::REFERENCE_STATES.include?(list_name) && !list.closed?
                 pos_adjustment = TrelloHelper::LIST_POSITION_ADJUSTMENT[list_name]
-                if TrelloHelper::ACCEPTED_STATES.include?(list_name) || list_name =~ TrelloHelper::SPRINT_REGEXES
+                if trello.list_for_completed_work?(list_name)
                   pos_adjustment = 0
                 end
                 pos_adjustment = TrelloHelper::MAX_LIST_POSITION_ADJUSTMENT unless pos_adjustment

--- a/templates/releases_overview.erb
+++ b/templates/releases_overview.erb
@@ -94,11 +94,11 @@
         complete = false
         status = 'Planned'
         pos_adjustment = TrelloHelper::LIST_POSITION_ADJUSTMENT[list_name]
-        if TrelloHelper::ACCEPTED_STATES.include?(list_name) || list_name =~ TrelloHelper::SPRINT_REGEXES
+        if trello.list_for_completed_work?(list_name)
           pos_adjustment = 0
           status = 'Complete'
           complete = true
-        elsif TrelloHelper::CURRENT_SPRINT_NOT_ACCEPTED_STATES.include?(list_name)
+        elsif trello.list_for_in_progress_work?(list_name)
           status = 'In Progress'
         end
         pos_adjustment = TrelloHelper::MAX_LIST_POSITION_ADJUSTMENT unless pos_adjustment

--- a/templates/teams_overview.erb
+++ b/templates/teams_overview.erb
@@ -79,11 +79,11 @@
         complete = false
         status = 'Planned'
         pos_adjustment = TrelloHelper::LIST_POSITION_ADJUSTMENT[list_name]
-        if TrelloHelper::ACCEPTED_STATES.include?(list_name) || list_name =~ TrelloHelper::SPRINT_REGEXES
+        if trello.list_for_completed_work?(list_name)
           pos_adjustment = 0
           status = 'Complete'
           complete = true
-        elsif TrelloHelper::CURRENT_SPRINT_NOT_ACCEPTED_STATES.include?(list_name)
+        elsif trello.list_for_in_progress_work?(list_name)
           status = 'In Progress'
         end
         pos_adjustment = TrelloHelper::MAX_LIST_POSITION_ADJUSTMENT unless pos_adjustment

--- a/test/files/std_config.yml
+++ b/test/files/std_config.yml
@@ -1,0 +1,59 @@
+---
+:consumer_key: abcdef1234567890abcdef1234567890
+:consumer_secret: abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+:oauth_token: abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+:max_lists_per_board: 26
+:default_product: product1
+:other_products:
+  - product2
+  - product3
+:product_order:
+  - product1
+  - product2
+  - product3
+:teams:
+  :team1:
+    :boards:
+      :team1_board1: 1abcdef1234567890abcdef1
+      :team1_board2: 2abcdef1234567890abcdef1
+    :dependent_work_boards:
+      3abcdef1234567890abcdef1:
+        :label: documentation
+        :new_list_name: New
+        :card_name_prefix: Team1-Document
+        :card_desc_prefix: Corresponding Development Card
+        :task_reminder_text: Update this card with team1-specific details about what needs to be documented.
+  :team2:
+    :boards:
+      :team2_board: 02abcdef1234567890abcdef
+  :team3:
+    :boards:
+      :team3_board: 03abcdef1234567890abcdef
+      :team3_board_private: 13abcdef1234567890abcdef
+    :exclude_from_sprint_report: true
+    :exclude_from_dependent_work_board: true
+:roadmap_id: 4abcdef1234567890abcdef1
+:public_roadmap_id: 5abcdef1234567890abcdef1
+:dependent_work_boards:
+  6abcdef1234567890abcdef1:
+    :label: documentation
+    :new_list_name: New
+    :card_name_prefix: Document
+    :card_desc_prefix: Corresponding Development Card
+    :task_reminder_text: Update this card (in the description or in a comment) with details about what needs to be documented.
+  7abcdef1234567890abcdef1:
+    :label: other_work
+    :new_list_name: New
+    :card_name_prefix: Other
+    :card_desc_prefix: Corresponding Development Card
+    :task_reminder_text: Update this card (in the description or in a comment) with details about any additional work required
+:organization_id: test_org_name
+:organization_name: Test Organization Name
+:roadmap_board_lists:
+ - 'New'
+ - 'Epic Backlog'
+:sprint_length_in_weeks: 3
+:sprint_start_day: monday
+:sprint_end_day: friday
+:logo: https://example.com/logo.png
+:archive_path: /history/

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,26 @@
+require 'minitest/autorun'
+require 'yaml'
+
+module SprintTools
+  class TestCase < MiniTest::Spec
+    ASSETS_DIR = File.expand_path File.join(File.dirname(__FILE__), 'files')
+    STD_CONFIG_FILE = File.join(ASSETS_DIR, 'std_config.yml')
+
+    def load_std_config
+      hashes = {}
+      hashes['trello'] = YAML.load_file(STD_CONFIG_FILE)
+      OpenStruct.new(hashes)
+    end
+
+    def load_conf(klass,args,single = false)
+      if single
+        klass.new(args)
+      else
+        Hash[*args.map do |key,val|
+               [key,klass.new(val)]
+             end.flatten]
+      end
+    end
+
+  end
+end

--- a/test/test_overviews_helper.rb
+++ b/test/test_overviews_helper.rb
@@ -1,0 +1,138 @@
+require 'helper'
+require 'overviews_helper'
+
+require 'csv'
+
+class TestOverviewsHelper < SprintTools::TestCase
+  def setup
+    super
+    @config = load_std_config
+    @trello = load_conf(TrelloHelper, @config.trello, true)
+    init_card_data
+    init_test_card
+    init_trello_mocker
+  end
+
+  def init_card_data
+    @card_data_no_products = { id: "a9abcdef0123456789abcdef",
+                               title: "Test card title - no products",
+                               card_size: "3",
+                               card_url: "https://trello.com/c/12AB34CD/",
+                               team_name: "team1",
+                               board_name: "team1_board1",
+                               board_url: "https://trello.com/b/98Bc76JF/team1-board1",
+                               list: "Accepted",
+                               status: "Complete",
+                               members: [ "Joe Example (jojo1)",
+                                          "James Doe (jamesdoe)"
+                                        ],
+                               products: {},
+                               epics: [ "epic-example-first", "epic-example-second" ]
+                             }
+
+    @card_csv_row_array_no_products = [ "",
+                                        "",
+                                        "",
+                                        "Test card title - no products",
+                                        "https://trello.com/c/12AB34CD/",
+                                        "team1",
+                                        "team1_board1",
+                                        "https://trello.com/b/98Bc76JF/team1-board1",
+                                        "Accepted",
+                                        "Complete",
+                                        "epic-example-first|epic-example-second",
+                                        "3",
+                                        "Joe Example (jojo1)|James Doe (jamesdoe)",
+                                        "a9abcdef0123456789abcdef"
+                                      ]
+  end
+
+  def init_test_card
+    test_card_fields = { "name" => "(3) Test card title - no products",
+                         "id" => "a9abcdef0123456789abcdef",
+                         "idList" => "000000000000000000000000",
+                         "idShort" => "12AB34CD",
+                         "desc" => "",
+                         "idMembers" => nil,
+                         "labels" => nil,
+                         "due" => nil,
+                         "pos" => nil,
+                         "shortUrl" => "https://trello.com/c/12AB34CD/"
+                       }
+    @test_card = Trello::Card.new(test_card_fields)
+  end
+
+  def init_trello_mocker
+    mock_member1 = Minitest::Mock.new
+    mock_member1.expect :full_name, "Joe Example"
+    mock_member1.expect :username, "jojo1"
+
+    mock_member2 = Minitest::Mock.new
+    mock_member2.expect :full_name, "James Doe"
+    mock_member2.expect :username, "jamesdoe"
+
+    mock_labels = [ "epic-example-first", "epic-example-second" ].map do |lname|
+      mock_label = Minitest::Mock.new
+      mock_label.expect :name, lname
+      mock_label
+    end
+
+    mock_list = Minitest::Mock.new
+    mock_list.expect :name, "Accepted"
+    mock_list.expect :name, "Accepted"
+
+    mock_board = Minitest::Mock.new
+    mock_board.expect :name, "team1_board1"
+    mock_board.expect :url, "https://trello.com/b/98Bc76JF/team1-board1"
+
+    @mock_trello = Minitest::Mock.new(@trello)
+    @mock_trello.expect :card_members, [ mock_member1, mock_member2 ], [@test_card]
+    @mock_trello.expect :card_labels, mock_labels, [@test_card]
+
+    @mock_trello.expect :other_products, nil
+    @mock_trello.expect :default_product, nil
+
+    @mock_trello.expect :teams, [['team1', {}]]
+    @mock_trello.expect :team_boards, [mock_board], ['team1']
+    @mock_trello.expect :board_lists, [mock_list], [mock_board]
+    @mock_trello.expect :list_cards, [@test_card], [mock_list]
+  end
+
+  # Validate output of csv prep function
+  #
+  def test_card_data_to_csv_row_array
+    overviews_helper = OverviewsHelper.new()
+    assert_equal(@card_csv_row_array_no_products, overviews_helper.card_data_to_csv_row_array(@card_data_no_products))
+  end
+
+  def test_card_data_from_card
+    mock_board = Minitest::Mock.new
+    mock_board.expect :name, "team1_board1"
+    mock_board.expect :url, "https://trello.com/b/98Bc76JF/team1-board1"
+
+    mock_list = Minitest::Mock.new
+    mock_list.expect :name, "Accepted"
+
+    overviews_helper = OverviewsHelper.new(trello: @mock_trello)
+
+    card_data = overviews_helper.card_data_from_card(@test_card, "team1", mock_board, mock_list, "Complete")
+
+    assert_equal(@card_data_no_products, card_data)
+  end
+
+  def test_create_raw_overview_data
+    csv_array = []
+    overviews_helper = OverviewsHelper.new(trello: @mock_trello)
+    copen = lambda { |fname, mode|
+      assert_equal 'test', fname
+      assert_equal 'wb', mode
+    }
+    CSV.stub(:open, copen, csv_array) do
+      overviews_helper.create_raw_overview_data("test")
+    end
+
+    assert_equal(csv_array, [OverviewsHelper::CSV_HEADER, @card_csv_row_array_no_products])
+  end
+
+end
+

--- a/test/test_trello_helper.rb
+++ b/test/test_trello_helper.rb
@@ -1,0 +1,54 @@
+require 'helper'
+require 'trello_helper'
+
+class TestTrelloHelper < SprintTools::TestCase
+  def setup
+    super
+    @config = load_std_config
+    @std_teams = {
+      :team1=>{
+        :boards=>{
+          :team1_board1=>"1abcdef1234567890abcdef1",
+          :team1_board2=>"2abcdef1234567890abcdef1"
+        },
+        :dependent_work_boards=>{
+          "3abcdef1234567890abcdef1"=>{
+            :label=>"documentation",
+            :new_list_name=>"New",
+            :card_name_prefix=>"Team1-Document",
+            :card_desc_prefix=>"Corresponding Development Card",
+            :task_reminder_text=>"Update this card with team1-specific details about what needs to be documented."
+          }
+        }
+      },
+      :team2=>{
+        :boards=>{
+          :team2_board=>"02abcdef1234567890abcdef"
+        }
+      },
+      :team3 => {
+        :boards => {
+          :team3_board => "03abcdef1234567890abcdef",
+          :team3_board_private => "13abcdef1234567890abcdef"
+        },
+        :exclude_from_sprint_report => true,
+        :exclude_from_dependent_work_board => true
+      }
+    }
+  end
+
+  # Silly test to validate equality of loaded config with hardcoded
+  # config. Only really tests the YAML loader, but you gotta start
+  # somewhere.
+  #
+  def test_teams
+    trello = load_conf(TrelloHelper, @config.trello, true)
+    assert_equal @std_teams, trello.teams
+  end
+
+  # Make sure the valid_products function works
+  def test_valid_products
+    trello = load_conf(TrelloHelper, @config.trello, true)
+    assert_equal(['product2', 'product3', 'product1'], trello.valid_products)
+  end
+end

--- a/trello
+++ b/trello
@@ -6,6 +6,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__) + '/lib') unless $LOAD_PATH.include?(F
 require 'config'
 require 'trello_helper'
 require 'output_helper'
+require 'overviews_helper'
 require 'reports'
 require 'report'
 require 'erb'
@@ -14,6 +15,8 @@ require 'yaml'
 require 'i18n'
 require 'commander/import'
 require 'bugzilla_helper'
+
+require 'csv'
 
 Encoding.default_external = "UTF-8"
 
@@ -64,66 +67,6 @@ LINKS = {'roadmap_overview' => 'Roadmap',
          'labels_overview' => 'Labels',
          'sprint_schedule' => 'Sprint Schedule'}
 
-def create_releases_overview(out, trello, bugzilla)
-  extname = File.extname out
-  filename = File.basename out, extname
-  dirname = File.dirname out
-
-  ((trello.other_products ? trello.other_products : []) + [nil]).each do |product|
-    erb = ERB.new(File.open('templates/releases_overview.erb', "rb").read)
-    file = nil
-    if product
-      file = File.join(dirname, "#{filename}_#{product}#{extname}")
-    else
-      file = out
-    end
-    File.open(file, 'w') {|f| f.write(erb.result(binding)) }
-  end
-end
-
-def create_teams_overview(out, trello, bugzilla)
-  extname = File.extname out
-  filename = File.basename out, extname
-  dirname = File.dirname out
-
-  (trello.teams.keys + [nil]).each do |team|
-    erb = ERB.new(File.open('templates/teams_overview.erb', "rb").read)
-    file = nil
-    if team
-      file = File.join(dirname, "#{filename}_#{team}#{extname}")
-    else
-      file = out
-    end
-    File.open(file, 'w') {|f| f.write(erb.result(binding)) }
-  end
-end
-
-def create_developers_overview(out, trello)
-  extname = File.extname out
-  filename = File.basename out, extname
-  dirname = File.dirname out
-
-  (trello.teams.keys + [nil]).each do |team|
-    erb = ERB.new(File.open('templates/developers_overview.erb', "rb").read)
-    file = nil
-    if team
-      file = File.join(dirname, "#{filename}_#{team}#{extname}")
-    else
-      file = out
-    end
-    File.open(file, 'w') {|f| f.write(erb.result(binding)) }
-  end
-end
-
-def create_labels_overview(out, trello)
-  erb = ERB.new(File.open('templates/labels_overview.erb', "rb").read)
-  File.open(out, 'w') {|f| f.write(erb.result(binding)) }
-end
-
-def create_roadmap_overview(out, trello)
-  erb = ERB.new(File.open('templates/roadmap_overview.erb', "rb").read)
-  File.open(out, 'w') {|f| f.write(erb.result(binding)) }
-end
 
 trello = load_conf(TrelloHelper, CONFIG.trello, true)
 
@@ -144,7 +87,7 @@ command :organize_release_cards do |c|
 
   c.option "--dry-run", "Show what changes would be made without actually making them"
 
-  c.syntax = "#{name}"
+  c.syntax = "#{name} organize_release_cards"
   c.description = "Rearrange board list cards sorted by release"
   c.action do |args, options|
     release_states = TrelloHelper::NEXT_STATES.keys + TrelloHelper::BACKLOG_STATES.keys
@@ -282,8 +225,8 @@ command :backup_org_boards do |c|
 
   c.option "--out-dir DIRECTORY", "Directory to dump backup json to"
 
-  c.syntax = "#{name}"
-  c.description = "dump all organization boards"
+  c.syntax = "#{name} backup_org_boards"
+  c.description = "dump a JSON backup of all organization boards to the specified directory"
   c.action do |args, options|
     output_dir = (options.out_dir.nil? || options.out_dir.empty?) ? Pathname.pwd : Pathname.new(options.out_dir)
     if !output_dir.writable?
@@ -362,9 +305,10 @@ command :list do |c|
 end
 
 command :list_roadmap_labels do |c|
-  c.syntax = "#{name} list"
+  c.syntax = "#{name} list_roadmap_labels"
 
-  c.option "--board board_name", "List labels on a particular board (defaults to Private AtomicOpenShift Roadmap)"
+  c.description = "List the labels belonging to a board, defaulting to the Roadmap board designated in the configuration."
+  c.option "--board BOARD_NAME", "List labels on a particular board"
   c.action do |args, options|
     if options.board_name
       board = trello.boards.find { |b| b.name == options.board_name }
@@ -442,7 +386,7 @@ end
 command :days_until_stage_one_dep_complete do |c|
   c.syntax = "#{name} days_until_stage_one_dep_complete"
 
-  c.description = "Print the number of days left until stage_one_dep_complete"
+  c.description = "Print the number of days left until stage one dependencies are feature complete"
   c.action do |args, options|
     sprint = Sprint.new({:trello => trello, :uninitialized => true})
     print ((sprint.stage_one_dep_complete.to_time - Time.new) / (60*60*24)).ceil
@@ -576,7 +520,8 @@ command :generate_roadmap_overview do |c|
   c.description = "Generate the overview of the roadmap board"
   c.action do |args, options|
     options.out ||= '/tmp/roadmap_overview.html'
-    create_roadmap_overview(options.out, trello)
+    overviews_helper = OverviewsHelper.new(trello: trello)
+    overviews_helper.create_roadmap_overview(options.out)
   end
 end
 
@@ -622,7 +567,8 @@ command :generate_labels_overview do |c|
   c.description = "Generate the labels overview"
   c.action do |args, options|
     options.out ||= '/tmp/labels_overview.html'
-    create_labels_overview(options.out, trello)
+    overviews_helper = OverviewsHelper.new(trello: trello)
+    overviews_helper.create_labels_overview(options.out)
   end
 end
 
@@ -636,7 +582,8 @@ command :generate_releases_overview do |c|
     bugzilla = load_conf(BugzillaHelper, CONFIG.bugzilla, true)
 
     options.out ||= '/tmp/releases_overview.html'
-    create_releases_overview(options.out, trello, bugzilla)
+    overviews_helper = OverviewsHelper.new(trello: trello, bugzilla: bugzilla)
+    overviews_helper.create_releases_overview(options.out)
   end
 end
 
@@ -650,7 +597,8 @@ command :generate_teams_overview do |c|
     bugzilla = load_conf(BugzillaHelper, CONFIG.bugzilla, true)
 
     options.out ||= '/tmp/teams_overview.html'
-    create_teams_overview(options.out, trello, bugzilla)
+    overviews_helper = OverviewsHelper.new(trello: trello, bugzilla: bugzilla)
+    overviews_helper.create_teams_overview(options.out)
   end
 end
 
@@ -662,7 +610,21 @@ command :generate_developers_overview do |c|
   c.description = "Generate the developers overview"
   c.action do |args, options|
     options.out ||= '/tmp/developers_overview.html'
-    create_developers_overview(options.out, trello)
+    overviews_helper = OverviewsHelper.new(trello: trello)
+    overviews_helper.create_developers_overview(options.out)
+  end
+end
+
+command :generate_raw_overview do |c|
+  c.syntax = "#{name} generate_raw_overview"
+
+  c.option "--out OUT_FILE", "The file to output Ex: /tmp/raw_overview.csv"
+
+  c.description = "Generate a CSV-formatted file containing the card data used in the overview pages, suitable to importing into a spreadsheet."
+  c.action do |args, options|
+    options.out ||= '/tmp/raw_overview.csv'
+    overviews_helper = OverviewsHelper.new(trello: trello)
+    overviews_helper.create_raw_overview_data(options.out)
   end
 end
 
@@ -677,11 +639,13 @@ command :generate_default_overviews do |c|
 
     options.out_dir ||= '/tmp'
 
-    create_roadmap_overview(File.join(options.out_dir, 'roadmap_overview.html'), trello)
-    create_releases_overview(File.join(options.out_dir, 'releases_overview.html'), trello, bugzilla)
-    create_labels_overview(File.join(options.out_dir, 'labels_overview.html'), trello)
-    create_teams_overview(File.join(options.out_dir, 'teams_overview.html'), trello, bugzilla)
-    create_developers_overview(File.join(options.out_dir, 'developers_overview.html'), trello)
+    overviews_helper = OverviewsHelper.new(trello: trello, bugzilla: bugzilla)
+    overviews_helper.create_roadmap_overview(File.join(options.out_dir, 'roadmap_overview.html'))
+    overviews_helper.create_releases_overview(File.join(options.out_dir, 'releases_overview.html'))
+    overviews_helper.create_labels_overview(File.join(options.out_dir, 'labels_overview.html'))
+    overviews_helper.create_teams_overview(File.join(options.out_dir, 'teams_overview.html'))
+    overviews_helper.create_developers_overview(File.join(options.out_dir, 'developers_overview.html'))
+    overviews_helper.create_raw_overview_data(File.join(options.out_dir, 'raw_overview.csv'))
 
     options.sprints = options.sprints ? options.sprints.to_i : 14
     options.offset = options.offset ? options.offset.to_i : 0
@@ -790,7 +754,7 @@ command :rename_label do |c|
   c.option "--from FROM", "The label to rename"
   c.option "--to TO", "What to rename it to"
 
-  c.description = "Renames a label on all the boards"
+  c.description = "Renames a label on all configured boards"
   c.action do |args, options|
 
     raise "--from not specified" if options.from.nil? || options.from.strip.empty?
@@ -824,7 +788,7 @@ end
 
 command :create_roadmap_labels do |c|
   c.syntax = "#{name} create_roadmap_labels LABEL1 LABEL2 ..."
-  c.description = "creates each of LABEL1 LABEL2 ... as labels on the roadmap board"
+  c.description = "creates each of LABEL1 LABEL2 ... as labels on the configured roadmap board"
   c.action do |args, options|
     puts "args: #{args} options: #{options}"
     roadmap_label_names = trello.board_labels(trello.roadmap_board).map{|l| l.name}
@@ -924,7 +888,7 @@ command :update do |c|
           dependent_work_valid = !(board.prefs['permissionLevel'] == 'org' && dep_work_board.prefs['permissionLevel'] != 'org')
           lists = trello.board_lists(board)
           lists.each do |list|
-            if TrelloHelper::CURRENT_SPRINT_NOT_ACCEPTED_STATES.include?(list.name)
+            if trello.list_for_in_progress_work?(list.name)
               cards = trello.list_cards(list)
               if !cards.empty?
                 puts "\n  List: #{list.name}  (#cards #{cards.length})"


### PR DESCRIPTION
`generate_raw_overview` generates CSV export for all overview content

Adds `overviews_helper.rb` to partition logic; unclutters `trello` script
and consolidates a lot of related functionality.

Adds tests for new raw overview methods

Cleans up warnings from `rake test`

Update `README.md` and polish some of the `--help` output