### PR TITLE
Adds json loader, backup for org and org members

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'activesupport', '<= 4.2.7.1'
 gem 'ruby-trello',   '<= 1.4.1'
 gem 'i18n'
 gem 'ruby-bugzilla'
-gem 'net-ldap'
+gem 'net-ldap', '<= 0.12.1'
+gem 'simplecov', :require => false, :group => :test
 
 gem 'commander'

--- a/lib/trello_json_loader.rb
+++ b/lib/trello_json_loader.rb
@@ -1,0 +1,108 @@
+require 'trello'
+require 'json'
+
+class TrelloJsonLoader
+  # attr_accessor :trello
+  attr_accessor :organizations_by_id, :boards_by_id, :cards_by_id, :checklists_by_id, :checklist_id_to_card_id, :labels_by_id, :lists_by_id, :members_by_id, :type_to_map, :organization_members
+
+  TYPES = ["organizations", "boards", "labels", "members", "cards", "checklists", "lists"]
+  TYPE_TO_CLASS = {
+    'organizations' => Trello::Organization,
+    'boards' => Trello::Board,
+    'labels' => Trello::Label,
+    'members' => Trello::Member,
+    'cards' => Trello::Card,
+    'checklists' => Trello::Checklist,
+    'lists' => Trello::List
+  }
+
+  def initialize
+    @organizations_by_id = {}
+    @boards_by_id = {}
+    @labels_by_id = {}
+    @members_by_id = {}
+    @organization_members = []
+    @cards_by_id = {}
+    @checklists_by_id = {}
+    @checklist_id_to_card_id = {}
+    @lists_by_id = {}
+    @type_to_map = {
+      'organizations' => @organizations_by_id,
+      'boards' =>        @boards_by_id,
+      'labels' =>        @labels_by_id,
+      'members' =>       @members_by_id,
+      'cards' =>         @cards_by_id,
+      'checklists' =>    @checklists_by_id,
+      'lists' =>         @lists_by_id
+    }
+  end
+
+  # Class methods section
+
+  def load_from_file(filespec, type)
+    File.open(filespec, 'r') do |json_file|
+      data = JSON.load(json_file)
+      load_any(data, type)
+    end
+  end
+
+  # Special case this since these are backed up as an Array of Hashes
+  def load_org_members_from_file(filespec)
+    File.open(filespec, 'r') do |json_file|
+      data = JSON.load(json_file)
+      data.each do |member_data|
+        @organization_members << load_any(member_data, 'members', false)
+      end
+    end
+  end
+
+  def load_any(data, type, nested=true)
+    dataobj = nil
+    if nested
+      TYPES.each do |nested_type|
+        if data[nested_type]
+          data[nested_type].each_with_object(@type_to_map[nested_type]) do |nested_obj, type_map|
+            load_any(nested_obj, nested_type)
+          end
+        end
+      end
+    end
+    begin
+      dataobj = TYPE_TO_CLASS[type].new(data)
+      type_to_map[type][dataobj.id] ||= dataobj
+      # Handle ruby-trello 1.3.0
+      if type == 'checklists' and data['idCard']
+        @checklist_id_to_card_id[dataobj.id] ||= data['idCard']
+      end
+    rescue Exception => e
+      $stderr.puts "Error while loading data of type #{type} with data: #{data.to_s[0..200]}"
+      raise
+    end
+    dataobj
+  end
+
+  def load_board(data)
+    load_any(data, 'boards')
+  end
+
+  def load_label(data)
+    load_any(data, 'labels')
+  end
+
+  def load_member(data)
+    load_any(data, 'members')
+  end
+
+  def load_card(data)
+    load_any(data, 'cards')
+  end
+
+  def load_checklist(data)
+    load_any(data, 'checklists')
+  end
+
+  def load_list(data)
+    load_any(data, 'lists')
+  end
+end
+

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'minitest/autorun'
 require 'yaml'
 

--- a/test/test_overviews_helper.rb
+++ b/test/test_overviews_helper.rb
@@ -9,7 +9,7 @@ class TestOverviewsHelper < SprintTools::TestCase
     @config = load_std_config
     @trello = load_conf(TrelloHelper, @config.trello, true)
     init_card_data
-    init_test_card
+    init_test_cards
     init_trello_mocker
   end
 
@@ -29,7 +29,6 @@ class TestOverviewsHelper < SprintTools::TestCase
                                products: {},
                                epics: [ "epic-example-first", "epic-example-second" ]
                              }
-
     @card_csv_row_array_no_products = [ "",
                                         "",
                                         "",
@@ -45,9 +44,67 @@ class TestOverviewsHelper < SprintTools::TestCase
                                         "Joe Example (jojo1)|James Doe (jamesdoe)",
                                         "a9abcdef0123456789abcdef"
                                       ]
+
+    @card_data_with_product_in_progress = { id: "aaabcdef0123456789abcdef",
+                                  title: "Test card 2 - with products [test_tag]",
+                                  card_size: "5",
+                                  card_url: "https://trello.com/c/12AB34CE/",
+                                  team_name: "team1",
+                                  board_name: "team1_board1",
+                                  board_url: "https://trello.com/b/98Bc76JF/team1-board1",
+                                  list: "In Progress",
+                                  status: "In Progress",
+                                  members: [ "James Doe (jamesdoe)" ],
+                                  products: { "product1" => ['5.1.2', 'proposed'] },
+                                  epics: [ "epic-example-second" ]
+                                }
+    @card_csv_row_array_with_product_in_progress = [ "product1",
+                                           "product1:5.1.2",
+                                           "product1:proposed",
+                                           "Test card 2 - with products [test_tag]",
+                                           "https://trello.com/c/12AB34CE/",
+                                           "team1",
+                                           "team1_board1",
+                                           "https://trello.com/b/98Bc76JF/team1-board1",
+                                           "In Progress",
+                                           "In Progress",
+                                           "epic-example-second",
+                                           "5",
+                                           "James Doe (jamesdoe)",
+                                           "aaabcdef0123456789abcdef"
+                                                   ]
+
+    @card_data_with_product_complete = { id: "ababcdef0123456789abcdef",
+                                         title: "Test card 3 - with complete product [test_tag]",
+                                         card_size: "8",
+                                         card_url: "https://trello.com/c/12AB34CF/",
+                                         team_name: "team1",
+                                         board_name: "team1_board1",
+                                         board_url: "https://trello.com/b/98Bc76JF/team1-board1",
+                                         list: "Accepted",
+                                         status: "Complete",
+                                         members: [ "Joe Example (jojo1)" ],
+                                         products: { "product1" => ['5.1.2', 'committed'] },
+                                         epics: [ "epic-example-second", "epic-example-third" ]
+                                       }
+    @card_csv_row_array_with_product_complete = [ "product1",
+                                                  "product1:5.1.2",
+                                                  "product1:committed",
+                                                  "Test card 3 - with complete product [test_tag]",
+                                                  "https://trello.com/c/12AB34CF/",
+                                                  "team1",
+                                                  "team1_board1",
+                                                  "https://trello.com/b/98Bc76JF/team1-board1",
+                                                  "Accepted",
+                                                  "Complete",
+                                                  "epic-example-second|epic-example-third",
+                                                  "8",
+                                                  "Joe Example (jojo1)",
+                                                  "ababcdef0123456789abcdef"
+                                                ]
   end
 
-  def init_test_card
+  def init_test_cards
     test_card_fields = { "name" => "(3) Test card title - no products",
                          "id" => "a9abcdef0123456789abcdef",
                          "idList" => "000000000000000000000000",
@@ -59,43 +116,100 @@ class TestOverviewsHelper < SprintTools::TestCase
                          "pos" => nil,
                          "shortUrl" => "https://trello.com/c/12AB34CD/"
                        }
-    @test_card = Trello::Card.new(test_card_fields)
+    @test_card_no_products = Trello::Card.new(test_card_fields)
+    test_card_fields = { "name" => "(5) Test card 2 - with products [test_tag]",
+                         "id" => "aaabcdef0123456789abcdef",
+                         "idList" => "000000000000000000000000",
+                         "idShort" => "12AB34CE",
+                         "desc" => "",
+                         "idMembers" => nil,
+                         "labels" => nil,
+                         "due" => nil,
+                         "pos" => nil,
+                         "shortUrl" => "https://trello.com/c/12AB34CE/"
+                       }
+    @test_card_product_in_progress = Trello::Card.new(test_card_fields)
+    test_card_fields = { "name" => "(8) Test card 3 - with complete product [test_tag]",
+                         "id" => "ababcdef0123456789abcdef",
+                         "idList" => "000000000000000000000000",
+                         "idShort" => "12AB34CF",
+                         "desc" => "",
+                         "idMembers" => nil,
+                         "labels" => nil,
+                         "due" => nil,
+                         "pos" => nil,
+                         "shortUrl" => "https://trello.com/c/12AB34CF/"
+                       }
+    @test_card_product_complete = Trello::Card.new(test_card_fields)
   end
 
   def init_trello_mocker
     mock_member1 = Minitest::Mock.new
     mock_member1.expect :full_name, "Joe Example"
     mock_member1.expect :username, "jojo1"
+    mock_member1.expect :full_name, "Joe Example"
+    mock_member1.expect :username, "jojo1"
 
     mock_member2 = Minitest::Mock.new
     mock_member2.expect :full_name, "James Doe"
     mock_member2.expect :username, "jamesdoe"
+    mock_member2.expect :full_name, "James Doe"
+    mock_member2.expect :username, "jamesdoe"
 
-    mock_labels = [ "epic-example-first", "epic-example-second" ].map do |lname|
+    mock_labels_no_products = [ "epic-example-first", "epic-example-second" ].map do |lname|
       mock_label = Minitest::Mock.new
       mock_label.expect :name, lname
       mock_label
     end
 
-    mock_list = Minitest::Mock.new
-    mock_list.expect :name, "Accepted"
-    mock_list.expect :name, "Accepted"
+    mock_labels_product_in_progress = [ "epic-example-second", "proposed-product1-5.1.2" ].map do |lname|
+      mock_label = Minitest::Mock.new
+      mock_label.expect :name, lname
+      mock_label
+    end
+
+    mock_labels_product_complete = [ "epic-example-second", "epic-example-third", "committed-product1-5.1.2" ].map do |lname|
+      mock_label = Minitest::Mock.new
+      mock_label.expect :name, lname
+      mock_label
+    end
+
+    mock_list_no_products = Minitest::Mock.new
+    mock_list_no_products.expect :name, "Accepted"
+    mock_list_no_products.expect :name, "Accepted"
+    mock_list_product_in_progress = Minitest::Mock.new
+    mock_list_product_in_progress.expect :name, "In Progress"
+    mock_list_product_in_progress.expect :name, "In Progress"
+    mock_list_product_in_progress.expect :name, "In Progress"
+    mock_list_product_complete = Minitest::Mock.new
+    mock_list_product_complete.expect :name, "Accepted"
+    mock_list_product_complete.expect :name, "Accepted"
 
     mock_board = Minitest::Mock.new
     mock_board.expect :name, "team1_board1"
     mock_board.expect :url, "https://trello.com/b/98Bc76JF/team1-board1"
+    mock_board.expect :name, "team1_board1"
+    mock_board.expect :url, "https://trello.com/b/98Bc76JF/team1-board1"
+    mock_board.expect :name, "team1_board1"
+    mock_board.expect :url, "https://trello.com/b/98Bc76JF/team1-board1"
 
     @mock_trello = Minitest::Mock.new(@trello)
-    @mock_trello.expect :card_members, [ mock_member1, mock_member2 ], [@test_card]
-    @mock_trello.expect :card_labels, mock_labels, [@test_card]
+    @mock_trello.expect :card_members, [ mock_member1, mock_member2 ], [@test_card_no_products]
+    @mock_trello.expect :card_labels, mock_labels_no_products, [@test_card_no_products]
+    @mock_trello.expect :card_members, [ mock_member2 ], [@test_card_product_in_progress]
+    @mock_trello.expect :card_labels, mock_labels_product_in_progress, [@test_card_product_in_progress]
+    @mock_trello.expect :card_members, [ mock_member1 ], [@test_card_product_complete]
+    @mock_trello.expect :card_labels, mock_labels_product_complete, [@test_card_product_complete]
 
     @mock_trello.expect :other_products, nil
     @mock_trello.expect :default_product, nil
 
     @mock_trello.expect :teams, [['team1', {}]]
     @mock_trello.expect :team_boards, [mock_board], ['team1']
-    @mock_trello.expect :board_lists, [mock_list], [mock_board]
-    @mock_trello.expect :list_cards, [@test_card], [mock_list]
+    @mock_trello.expect :board_lists, [mock_list_no_products, mock_list_product_in_progress, mock_list_product_complete], [mock_board]
+    @mock_trello.expect :list_cards, [@test_card_no_products], [mock_list_no_products]
+    @mock_trello.expect :list_cards, [@test_card_product_in_progress], [mock_list_product_in_progress]
+    @mock_trello.expect :list_cards, [@test_card_product_complete], [mock_list_product_complete]
   end
 
   # Validate output of csv prep function
@@ -109,28 +223,35 @@ class TestOverviewsHelper < SprintTools::TestCase
     mock_board = Minitest::Mock.new
     mock_board.expect :name, "team1_board1"
     mock_board.expect :url, "https://trello.com/b/98Bc76JF/team1-board1"
+    mock_board.expect :name, "team1_board1"
+    mock_board.expect :url, "https://trello.com/b/98Bc76JF/team1-board1"
+    mock_board.expect :name, "team1_board1"
+    mock_board.expect :url, "https://trello.com/b/98Bc76JF/team1-board1"
 
     mock_list = Minitest::Mock.new
+    mock_list.expect :name, "Accepted"
+    mock_list.expect :name, "In Progress"
     mock_list.expect :name, "Accepted"
 
     overviews_helper = OverviewsHelper.new(trello: @mock_trello)
 
-    card_data = overviews_helper.card_data_from_card(@test_card, "team1", mock_board, mock_list, "Complete")
-
+    card_data = overviews_helper.card_data_from_card(@test_card_no_products, "team1", mock_board, mock_list, "Complete")
     assert_equal(@card_data_no_products, card_data)
+
+    card_data = overviews_helper.card_data_from_card(@test_card_product_in_progress, "team1", mock_board, mock_list, "In Progress")
+    assert_equal(@card_data_with_product_in_progress, card_data)
+
+    card_data = overviews_helper.card_data_from_card(@test_card_product_complete, "team1", mock_board, mock_list, "Complete")
+    assert_equal(@card_data_with_product_complete, card_data)
   end
 
   def test_create_raw_overview_data
     csv_array = []
     overviews_helper = OverviewsHelper.new(trello: @mock_trello)
-    copen = lambda { |fname, mode|
-      assert_equal 'test', fname
-      assert_equal 'wb', mode
-    }
-    CSV.stub(:open, copen, csv_array) do
+    CSV.stub(:open, nil, csv_array) do
       overviews_helper.create_raw_overview_data("test")
     end
 
-    assert_equal(csv_array, [OverviewsHelper::CSV_HEADER, @card_csv_row_array_no_products])
+    assert_equal([OverviewsHelper::CSV_HEADER, @card_csv_row_array_no_products, @card_csv_row_array_with_product_in_progress, @card_csv_row_array_with_product_complete], csv_array)
   end
 end

--- a/test/test_trello_helper.rb
+++ b/test/test_trello_helper.rb
@@ -51,4 +51,5 @@ class TestTrelloHelper < SprintTools::TestCase
     trello = load_conf(TrelloHelper, @config.trello, true)
     assert_equal(['product2', 'product3', 'product1'], trello.valid_products)
   end
+
 end

--- a/test/test_trello_helper_add_methods.rb
+++ b/test/test_trello_helper_add_methods.rb
@@ -1,0 +1,84 @@
+require 'helper'
+require 'trello_helper'
+
+class TestTrelloHelperAddMethods < SprintTools::TestCase
+  def setup
+    super
+    @config = load_std_config
+  end
+
+  # Check that new boards are placed in the correct caching objects
+  # and all expected side effects occur
+  def test_add_board
+    trello = load_conf(TrelloHelper, @config.trello, true)
+
+    mock_team_board = Minitest::Mock.new
+    mock_team_board.expect :name, "team1_board1"
+    mock_team_board.expect :url, "https://trello.com/b/98Bc76JF/team1-board1"
+    mock_team_board.expect :id, "1abcdef1234567890abcdef1"
+    mock_team_board.expect :id, "1abcdef1234567890abcdef1"
+
+    mock_public_roadmap_board = Minitest::Mock.new
+    mock_public_roadmap_board.expect :name, "Roadmap"
+    mock_public_roadmap_board.expect :url, "https://trello.com/b/aaaabbbb/roadmap"
+    mock_public_roadmap_board.expect :id, "5abcdef1234567890abcdef1"
+    mock_public_roadmap_board.expect :id, "5abcdef1234567890abcdef1"
+    mock_public_roadmap_board.expect :id, "5abcdef1234567890abcdef1"
+    mock_public_roadmap_board.expect :id, "5abcdef1234567890abcdef1"
+
+    mock_private_roadmap_board = Minitest::Mock.new
+    mock_private_roadmap_board.expect :name, "Private Roadmap"
+    mock_private_roadmap_board.expect :url, "https://trello.com/b/aaaabbbc/roadmap"
+    mock_private_roadmap_board.expect :id, "4abcdef1234567890abcdef1"
+    mock_private_roadmap_board.expect :id, "4abcdef1234567890abcdef1"
+    mock_private_roadmap_board.expect :id, "4abcdef1234567890abcdef1"
+    mock_private_roadmap_board.expect :id, "4abcdef1234567890abcdef1"
+
+    trello.add_board(mock_team_board)
+    # Should appear as a team board
+    assert_equal({"1abcdef1234567890abcdef1" => mock_team_board}, trello.boards)
+
+    trello.add_board(mock_public_roadmap_board)
+    # Public roadmap should not appear as a team board
+    refute_equal( { "5abcdef1234567890abcdef1" => mock_team_board }, trello.boards)
+    # Public roadmap should match trello.public_roadmap_board
+    assert_equal("5abcdef1234567890abcdef1", trello.public_roadmap_board.id)
+
+    trello.add_board(mock_private_roadmap_board)
+    # Private roadmap should also not appear as a team board.
+    refute_equal( { "4abcdef1234567890abcdef1" => mock_team_board }, trello.boards)
+    # Private roadmap should not appear as the public roadmap.
+    refute_equal("4abcdef1234567890abcdef1", trello.public_roadmap_board.id)
+    # Private roadmap should match trello.roadmap_board
+    assert_equal("4abcdef1234567890abcdef1", trello.roadmap_board.id)
+  end
+
+  def test_add_label
+    mock_label_name = "mock_label"
+
+    trello = load_conf(TrelloHelper, @config.trello, true)
+
+    mock_label_id = "1abcd0000000000000000002"
+    mock_label = Minitest::Mock.new
+    mock_label.expect :id, mock_label_id
+    mock_label.expect :id, mock_label_id
+    mock_label.expect :id, mock_label_id
+    mock_label.expect :name, mock_label_name
+
+    trello.add_label(mock_label)
+    assert_equal(mock_label_id, trello.label_by_id(mock_label_id).id)
+
+    mock_label_id = "1abcd0000000000000000001"
+    Trello::Label.stub(:find, nil) do
+      assert_nil(trello.label_by_id(mock_label_id))
+    end
+
+    mock_label_name = "mock_label_2"
+    mock_label_id = "1abcd0000000000000000003"
+    mock_label = Minitest::Mock.new
+    mock_label.expect :id, mock_label_id
+    mock_label.expect :id, mock_label_id
+    assert_equal(mock_label_id, trello.label_by_id(mock_label_id, {"id" => mock_label_id, "name" => mock_label_name}).id)
+
+  end
+end

--- a/trello
+++ b/trello
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__) + '/lib') unless $LOAD_PATH.include?(F
 
 require 'config'
 require 'trello_helper'
+require 'trello_json_loader'
 require 'output_helper'
 require 'overviews_helper'
 require 'reports'
@@ -15,7 +16,6 @@ require 'yaml'
 require 'i18n'
 require 'commander/import'
 require 'bugzilla_helper'
-
 require 'csv'
 
 Encoding.default_external = "UTF-8"
@@ -70,7 +70,7 @@ LINKS = { 'roadmap_overview' => 'Roadmap',
 ONE_DAY = 60 * 60 * 24
 
 trello = load_conf(TrelloHelper, CONFIG.trello, true)
-
+json_loader = TrelloJsonLoader.new
 # Generate a formatted string representing the sortable card for
 # dry-run output
 def card_data_string(card)
@@ -80,6 +80,31 @@ def card_data_string(card)
     " " * 30
   end
   "#{labeldata} %-4d pos: %-20s name: [%-30s]" % [card.card.short_id, "#{card.new_pos}", card.card.name[0..29]]
+end
+
+global_option "--load-dir LOADDIR", "Load sprint *board* data from *.json backups in LOADDIR" do |loaddir|
+  json_files = Dir.glob(File.join(loaddir, "*.json")).map { |f| File.expand_path(f) }
+  # Load org and org members first, since they're special
+  org_prefix = File.expand_path("#{loaddir}/#{TrelloHelper::ORG_BACKUP_PREFIX}")
+  org_members_prefix = File.expand_path("#{loaddir}/#{TrelloHelper::ORG_MEMBERS_BACKUP_PREFIX}")
+
+  if json_files.any? { |fname| fname.match(/^#{org_prefix}/) }
+    json_filespec = json_files.delete_at(json_files.index { |fname| fname.match(/^#{org_prefix}/) })
+    $stderr.puts "*** Loading org data from #{json_filespec}"
+    json_loader.load_from_file(json_filespec, "organizations")
+  end
+
+  if json_files.any? { |fname| fname.match(/^#{org_members_prefix}/) }
+    json_filespec = json_files.delete_at(json_files.index { |fname| fname.match(/^#{org_members_prefix}/) })
+    $stderr.puts "*** Loading org members data from #{json_filespec}"
+    json_loader.load_org_members_from_file(json_filespec)
+  end
+  # Load board data
+  json_files.sort.each do |json_filespec|
+    $stderr.puts "*** Loading board data from #{json_filespec}"
+    json_loader.load_from_file(json_filespec, "boards")
+  end
+  trello.add_json_loader_content(json_loader)
 end
 
 # Sort only the release cards by their release label, release number
@@ -245,8 +270,27 @@ command :backup_org_boards do |c|
           File.open(out_path, 'w') { |f| f.write(output) }
         rescue Exception => e
           $stderr.puts "Error while writing to #{out_path}: #{e.message}"
+          raise
         end
       end
+    end
+    out_filename = "#{TrelloHelper::ORG_BACKUP_PREFIX}#{trello.org.name}.json"
+    out_path = File.join(output_dir, out_filename)
+    begin
+      output = trello.dump_org_json()
+      File.open(out_path, 'w') { |f| f.write(output) }
+    rescue Exception => e
+      $stderr.puts "Error while writing to #{out_path}: #{e.message}"
+      raise
+    end
+    out_filename = "#{TrelloHelper::ORG_MEMBERS_BACKUP_PREFIX}#{trello.org.name}.json"
+    out_path = File.join(output_dir, out_filename)
+    begin
+      output = trello.dump_org_members_json()
+      File.open(out_path, 'w') { |f| f.write(output) }
+    rescue Exception => e
+      $stderr.puts "Error while writing to #{out_path}: #{e.message}"
+      raise
     end
   end
 end


### PR DESCRIPTION
This change was started to add JSON backup loading, so overview pages,
reports, etc. could be generated from backed up content without having
to query the API at all. This also will help make it easier to add unit
tests, new functionality like templated Trello object primitives - e.g. to
simplify creating new boards - etc.

Implementing the JSON loader exposed some problems with the Org boards
backup functionality which is also fixed in this change. Additionally,
backing up at the Org level is now supported, as is backing up the
current Org members list.

New methods for consistently adding new objects to the TrelloHelper
cache vars have been added, `add_card`, `add_label`, etc.

Tests for some of these things have been added, but to make concurrent
changes easier, the remainder of the tests will be written after this
merge. I have verified that the output of the trello commands (such as
generate_default_overviews) hasn't been altered as a result of this
change.

This is a huge change, but the central logic for things like overview
pages and sprint helpers is unchanged.