### PR TITLE
fix dependent work board logic, optimize `trello list`

### DIFF
--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -1328,14 +1328,14 @@ class TrelloHelper
         field = action.data['old'].keys.first
         if ['desc', 'pos', 'name'].include?(field)
           list_name = action.data['list']['name']
-          puts "#{action.member_creator.username} (#{list_name}):"
+          puts "#{members_by_id[action.member_creator_id].username} (#{list_name}):"
           puts "    New #{field}: #{action.data['card'][field]}"
           puts "    Old #{field}: #{action.data['old'][field]}"
           puts "===============================================\n\n"
         end
       elsif action.type == 'createCard'
         list_name = action.data['list']['name']
-        puts "#{action.member_creator.username} added to #{list_name}"
+        puts "#{members_by_id[action.member_creator_id].username} added to #{list_name}"
         puts "    Name: #{action.data['card']['name']}"
       end
     end

--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -701,7 +701,11 @@ class TrelloHelper
   end
 
   def dependent_work_board_ids
-    @dependent_work_board_ids ||= dependent_work_boards.keys + teams.select { |k, v| v.include? :dependent_work_boards }.map { |t, v| v[:dependent_work_boards].keys }.flatten
+    @dependent_work_board_ids ||= if !dependent_work_boards
+      [] # can't iterate over nil
+    else
+      dependent_work_boards.keys + teams.select { |k, v| v.include? :dependent_work_boards }.map { |t, v| v[:dependent_work_boards].keys }.flatten
+    end
   end
 
   def next_dependent_work_list(board_id = dependent_work_board.id, new_list_name = 'New')

--- a/lib/trello_helper.rb
+++ b/lib/trello_helper.rb
@@ -135,6 +135,7 @@ class TrelloHelper
       config.oauth_token = @oauth_token
     end
 
+    @members_by_id = {}
     @board_members = {}
     @cards_by_list = {}
     @labels_by_card = {}
@@ -461,7 +462,7 @@ class TrelloHelper
       members << member if !members.map { |m| m.respond_to?(:id) ? m.id : [] }.include?(member.id)
       @board_members[board.id] = members
     end
-    members_by_id[member.id] ||= member
+    members_by_id[member.id] = member
   end
 
   ##
@@ -1188,18 +1189,42 @@ class TrelloHelper
 
   def card_members(card)
     members = @members_by_card[card.id]
-    return members if members
+    # If the list we get doesn't match the card, refresh
+    return members if members && members.size == card.member_ids.size
     members = card.member_ids.map do |member_id|
-      member = members_by_id[member_id]
+      # if not cached member, get member info from cached board member api endpoint
+      member = members_by_id[member_id] || board_members(boards[card.board_id]).select { |m| member_id == m.id }.first
       if !member
-        # not an org member, get member info from board member api endpoint
+        # if not in the cached board member list, refresh the cached board members
+        $stderr.puts("Clearing @board_members cache for board id #{card.board_id}")
+        @board_members.delete(card.board_id)
         member = board_members(boards[card.board_id]).select { |m| member_id == m.id }.first
       end
-      @members_by_id[member_id] = member
-      member
+      add_member(member)
     end
     @members_by_card[card.id] = members if members
+    members.each { |member| add_member(member) }
     members
+  end
+
+  def create_missing_member(member_id)
+    Trello::Member.new({'id' => member_id, 'username' => 'deleted_account', 'fullName' => 'deleted account'})
+  end
+
+  def action_member_creator(action)
+    member = nil
+    if !(member = members_by_id[action.member_creator_id])
+      trello_do("action.member_creator") do
+        begin
+          member = action.member_creator
+        rescue Trello::Error => e
+          if e.message =~ /The requested resource was not found/ # 404
+            member = create_missing_member(action.member_creator_id)
+          end
+        end
+      end
+    end
+    add_member(member)
   end
 
   def board_labels(board)
@@ -1328,14 +1353,14 @@ class TrelloHelper
         field = action.data['old'].keys.first
         if ['desc', 'pos', 'name'].include?(field)
           list_name = action.data['list']['name']
-          puts "#{members_by_id[action.member_creator_id].username} (#{list_name}):"
+          puts "#{action_member_creator(action).username} (#{list_name}):"
           puts "    New #{field}: #{action.data['card'][field]}"
           puts "    Old #{field}: #{action.data['old'][field]}"
           puts "===============================================\n\n"
         end
       elsif action.type == 'createCard'
         list_name = action.data['list']['name']
-        puts "#{members_by_id[action.member_creator_id].username} added to #{list_name}"
+        puts "#{action_member_creator(action).username} added to #{list_name}"
         puts "    Name: #{action.data['card']['name']}"
       end
     end
@@ -1397,12 +1422,15 @@ class TrelloHelper
   def org_members
     @org_members || trello_do('org_members') do
       @org_members = target(org.members)
+      @org_members.each { |member| add_member(member) }
       return @org_members
     end
   end
 
   def members_by_id
-    @members_by_id ||= Hash[org_members.map { |m| [m.id, m] }]
+    org_members if !@org_members # Make sure at least the organization
+                                 # members are populated
+    @members_by_id
   end
 
   def board(board_id)

--- a/test/files/no_dependent_work_boards_config.yml
+++ b/test/files/no_dependent_work_boards_config.yml
@@ -1,0 +1,38 @@
+---
+:consumer_key: abcdef1234567890abcdef1234567890
+:consumer_secret: abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+:oauth_token: abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+:max_lists_per_board: 26
+:default_product: product1
+:other_products:
+  - product2
+  - product3
+:product_order:
+  - product1
+  - product2
+  - product3
+:teams:
+  :team1:
+    :boards:
+      :team1_board1: 1abcdef1234567890abcdef1
+      :team1_board2: 2abcdef1234567890abcdef1
+  :team2:
+    :boards:
+      :team2_board: 02abcdef1234567890abcdef
+  :team3:
+    :boards:
+      :team3_board: 03abcdef1234567890abcdef
+      :team3_board_private: 13abcdef1234567890abcdef
+    :exclude_from_sprint_report: true
+:roadmap_id: 4abcdef1234567890abcdef1
+:public_roadmap_id: 5abcdef1234567890abcdef1
+:organization_id: test_org_name
+:organization_name: Test Organization Name
+:roadmap_board_lists:
+ - 'New'
+ - 'Epic Backlog'
+:sprint_length_in_weeks: 3
+:sprint_start_day: monday
+:sprint_end_day: friday
+:logo: https://example.com/logo.png
+:archive_path: /history/

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,11 +8,20 @@ module SprintTools
   class TestCase < MiniTest::Spec
     ASSETS_DIR = File.expand_path File.join(File.dirname(__FILE__), 'files')
     STD_CONFIG_FILE = File.join(ASSETS_DIR, 'std_config.yml')
+    NO_DEP_WORK_BDS_CONFIG_FILE = File.join(ASSETS_DIR, 'no_dependent_work_boards_config.yml')
+
+    def load_config(config_file)
+      hashes = {}
+      hashes['trello'] = YAML.load_file(config_file)
+      OpenStruct.new(hashes)
+    end
 
     def load_std_config
-      hashes = {}
-      hashes['trello'] = YAML.load_file(STD_CONFIG_FILE)
-      OpenStruct.new(hashes)
+      load_config(STD_CONFIG_FILE)
+    end
+
+    def load_no_dep_work_boards_config
+      load_config(NO_DEP_WORK_BDS_CONFIG_FILE)
     end
 
     def load_conf(klass, args, single = false)

--- a/test/test_trello_helper.rb
+++ b/test/test_trello_helper.rb
@@ -52,4 +52,17 @@ class TestTrelloHelper < SprintTools::TestCase
     assert_equal(['product2', 'product3', 'product1'], trello.valid_products)
   end
 
+  # Validate behavior when dependent work boards are defined
+  def test_dependent_work_board_ids_defined
+    trello = load_conf(TrelloHelper, @config.trello, true)
+    assert_equal(['6abcdef1234567890abcdef1', '7abcdef1234567890abcdef1'], trello.dependent_work_board_ids)
+  end
+
+  # Validate behavior when dependent work boards aren't defined
+  def test_dependent_work_board_ids_defined
+    cfg = load_no_dep_work_boards_config
+    trello = load_conf(TrelloHelper, cfg.trello, true)
+    assert_equal([], trello.dependent_work_board_ids)
+  end
+
 end

--- a/trello
+++ b/trello
@@ -926,7 +926,7 @@ command :update do |c|
         team_map = trello.board_id_to_team_map[board_id]
         # Use the team dependent work boards if set, default to global
         # dependent work boards
-        dependent_work_boards = team_map[:dependent_work_boards] || trello.dependent_work_boards
+        dependent_work_boards = team_map[:dependent_work_boards] || trello.dependent_work_boards || {} # can't call .each on nil
         dependent_work_boards.each do |dep_work_board_id, dep_work_board_params|
           dep_work_board = trello.boards[dep_work_board_id]
           puts "\nBoard Name: #{board.name}"

--- a/trello
+++ b/trello
@@ -330,6 +330,7 @@ command :list do |c|
       end
 
       boards.each do |board|
+        trello.board_members(board) # seed the cache with board-specific members
         puts "\nBoard Name: #{board.name}"
         lists = trello.board_lists(board)
         if options.list


### PR DESCRIPTION
Fix exceptions when no dependent work boards are defined.

Also uses `members_by_id` caching method to get member data for `trello list` instead of pounding the `/1/members/` API endpoint, which invariably trips the rate limiter. Using the caching method incidentally adds retry logic as well, so it shouldn't bail out so easily now.